### PR TITLE
Feature #A: Modify random string generator to generate only hex values

### DIFF
--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -6,9 +6,9 @@ import (
 
 var randx = rand.NewSource(42)
 
-// RandString returns a random string of length n.
+// RandString returns a random hex string of length n.
 func RandString(n int) string {
-	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	const letterBytes = "abcdef0123456789"
 	const (
 		letterIdxBits = 6                    // 6 bits to represent a letter index
 		letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -1,10 +1,13 @@
 package util
 
 import (
+	"encoding/hex"
 	"math/rand"
 )
 
-var randx = rand.NewSource(42)
+const seed int64 = 42
+
+var randx = rand.NewSource(seed)
 
 // RandString returns a random hex string of length n.
 func RandString(n int) string {
@@ -30,4 +33,28 @@ func RandString(n int) string {
 	}
 
 	return string(b)
+}
+
+// RandHexString is an alternative implementation that returns a random
+// hex string of length n.
+func RandHexString(n int) string {
+	// Create local RNG
+	randx := rand.New(rand.NewSource(seed))
+
+	// Calculate number of bytes needed
+	fullBytes := n / 2
+	extraByte := n % 2
+
+	// Generate random bytes
+	bytes := make([]byte, fullBytes+extraByte)
+	randx.Read(bytes)
+
+	// Convert bytes to hex string
+	hexStr := hex.EncodeToString(bytes)
+
+	// If n is odd, trim last char
+	if extraByte == 1 {
+		hexStr = hexStr[:n]
+	}
+	return hexStr
 }

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -26,3 +26,25 @@ func TestRandString(t *testing.T) {
 		})
 	}
 }
+
+func TestRandHexString(t *testing.T) {
+	tests := []struct {
+		length   int
+		expected string
+	}{
+		{0, ""},
+		{3, "cb2"},
+		{5, "0400d"},
+		{10, "d814ba6367"},
+		{10, "3f9cfcba71"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.length), func(t *testing.T) {
+			actual := RandString(test.length)
+			if actual != test.expected {
+				t.Fatalf("length: %v, expected: %v, actual: %v", test.length, test.expected, actual)
+			}
+		})
+	}
+}

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -48,3 +48,47 @@ func TestRandHexString(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkRandString10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandString(10)
+	}
+}
+func BenchmarkRandHexString10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandHexString(10)
+	}
+}
+
+func BenchmarkRandString100(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandString(100)
+	}
+}
+func BenchmarkRandHexString100(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandHexString(100)
+	}
+}
+
+func BenchmarkRandString1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandString(1000)
+	}
+}
+func BenchmarkRandHexString1000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandHexString(1000)
+	}
+}
+
+func BenchmarkRandString10000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandString(10000)
+	}
+}
+func BenchmarkRandHexString10000(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = RandHexString(10000)
+	}
+}

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRandString(t *testing.T) {
+	tests := []struct {
+		length   int
+		expected string
+	}{
+		{0, ""},
+		{3, "33e"},
+		{5, "de607"},
+		{10, "9e1dee6f7a"},
+		{10, "20e65b801c"},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%v", test.length), func(t *testing.T) {
+			actual := RandString(test.length)
+			if actual != test.expected {
+				t.Fatalf("length: %v, expected: %v, actual: %v", test.length, test.expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Modified original implementation of `RandString` to contain only the appropriate hex values of `letterBytes`.
Also, added alternative implementation with name `RandHexString` to generate only hex values.

Bellow is the benchmark results between the 2 implementations for the following input sizes `10`, `100`, `1000`, `10000`:
```
$ go test -bench=. -benchtime=10s
goos: linux
goarch: amd64
pkg: goapp/pkg/util
cpu: Intel(R) Core(TM) i5-4300U CPU @ 1.90GHz
BenchmarkRandString10-4                 46098606             251.2 ns/op
BenchmarkRandHexString10-4                805054             13520 ns/op
BenchmarkRandString100-4                 5952673              1921 ns/op
BenchmarkRandHexString100-4               820122             13785 ns/op
BenchmarkRandString1000-4                 582345             18713 ns/op
BenchmarkRandHexString1000-4              686385             15812 ns/op
BenchmarkRandString10000-4                 64885            184866 ns/op
BenchmarkRandHexString10000-4             324540             37192 ns/op
```