### PR TITLE
 Feature #A: Fix random string generators to generate hex values  in capital

### DIFF
--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -11,7 +11,7 @@ var randx = rand.NewSource(seed)
 
 // RandString returns a random hex string of length n.
 func RandString(n int) string {
-	const letterBytes = "abcdef0123456789"
+	const letterBytes = "ABCDEF0123456789"
 	const (
 		letterIdxBits = 6                    // 6 bits to represent a letter index
 		letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits

--- a/pkg/util/string.go
+++ b/pkg/util/string.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/hex"
 	"math/rand"
+	"strings"
 )
 
 const seed int64 = 42
@@ -56,5 +57,5 @@ func RandHexString(n int) string {
 	if extraByte == 1 {
 		hexStr = hexStr[:n]
 	}
-	return hexStr
+	return strings.ToUpper(hexStr)
 }

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -33,15 +33,15 @@ func TestRandHexString(t *testing.T) {
 		expected string
 	}{
 		{0, ""},
-		{3, "cb2"},
-		{5, "0400d"},
-		{10, "d814ba6367"},
-		{10, "3f9cfcba71"},
+		{3, "538"},
+		{5, "538c7"},
+		{10, "538c7f96b1"},
+		{10, "538c7f96b1"},
 	}
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("%v", test.length), func(t *testing.T) {
-			actual := RandString(test.length)
+			actual := RandHexString(test.length)
 			if actual != test.expected {
 				t.Fatalf("length: %v, expected: %v, actual: %v", test.length, test.expected, actual)
 			}

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -34,9 +34,9 @@ func TestRandHexString(t *testing.T) {
 	}{
 		{0, ""},
 		{3, "538"},
-		{5, "538c7"},
-		{10, "538c7f96b1"},
-		{10, "538c7f96b1"},
+		{5, "538C7"},
+		{10, "538C7F96B1"},
+		{10, "538C7F96B1"},
 	}
 
 	for _, test := range tests {

--- a/pkg/util/string_test.go
+++ b/pkg/util/string_test.go
@@ -11,10 +11,10 @@ func TestRandString(t *testing.T) {
 		expected string
 	}{
 		{0, ""},
-		{3, "33e"},
-		{5, "de607"},
-		{10, "9e1dee6f7a"},
-		{10, "20e65b801c"},
+		{3, "33E"},
+		{5, "DE607"},
+		{10, "9E1DEE6F7A"},
+		{10, "20E65B801C"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Update benchmark results, after fixes:
```
$ go test -bench=. -benchtime=10s
goos: linux
goarch: amd64
pkg: goapp/pkg/util
cpu: Intel(R) Core(TM) i5-4300U CPU @ 1.90GHz
BenchmarkRandString10-4                 45193066             252.8 ns/op
BenchmarkRandHexString10-4                854308             13792 ns/op
BenchmarkRandString100-4                 6121452              1917 ns/op
BenchmarkRandHexString100-4               806372             14302 ns/op
BenchmarkRandString1000-4                 609897             19437 ns/op
BenchmarkRandHexString1000-4              556822             27188 ns/op
BenchmarkRandString10000-4                 62853            188761 ns/op
BenchmarkRandHexString10000-4             104631            114165 ns/op
```