### PR TITLE
Problem #2: Reduce memory allocations when opening many WS sessions 

### DIFF
--- a/internal/pkg/httpsrv/handler_websocket.go
+++ b/internal/pkg/httpsrv/handler_websocket.go
@@ -92,8 +92,7 @@ func (s *Server) handlerWebSocket(w http.ResponseWriter, r *http.Request) {
 	for {
 		select {
 		case cv := <-watch.Recv():
-			data, _ := json.Marshal(cv)
-			err = c.WriteMessage(websocket.TextMessage, data)
+			err = c.WriteJSON(cv)
 			if err != nil {
 				if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 					log.Printf("failed to write message: %v\n", err)


### PR DESCRIPTION
## Issue
A more than normal memory usage is observed after many WS sessions which needs investigation. After, some benchmarking with many WS sessions open in parallel, a large part of the allocation

## Solution
Instead of first using `json.Marshal` to encode each message and then writing it to the WebSocket connection, write it directly using the `WriteJSON` method.

## Benchmarks
To have a common test to compare the performance of the current implementation to any improvements we made, we run the following:

- `./bin/server` running
- 4 x `./bin/clients` running - with 1000 connections each = total of 4000 connections in parallel
- Total runtime of 5 minutes for each client
- Heap/Allocation profiling with `"net/http/pprof"

## Benchmarks Results
The heap and allocation information have been fetched from the debug `"net/http/pprof"` HTTP server:
```bash
wget localhost:6060/debug/pprof/heap -O heap
wget http://localhost:6060/debug/pprof/allocs -O allocs
```

The following flame graphs are being generated with Go `pprof` tool:
```bash
go tool pprof -http=:9091 heap
go tool pprof -http=:9091 allocs
```
![alloc_orig](https://github.com/user-attachments/assets/d53cd5b8-d4c4-431e-9590-a6e16d4d7054)
![alloc_enc](https://github.com/user-attachments/assets/39060640-91d6-42f5-8744-11c96db0b627)

### Memory Allocations
- Original implementations: 
  - Total: `93.22MB`
  - JSON encoding: `33MB (35.4%)`
- Improved implementation: 
  - Total: `71.62MB`
  - JSON encoding: `16.5MB (23%)`

Memory Allocation decrease:
- Total: `23%`
- JSON encoding: `50%`



